### PR TITLE
Support for react-leaflet 3

### DIFF
--- a/dev-env/App.jsx
+++ b/dev-env/App.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Map, TileLayer } from "react-leaflet";
+import { MapContainer, TileLayer } from "react-leaflet";
 
 import AntPath from "../src/AntPathContainer";
 import Logger from "./utils/Logger";
@@ -31,14 +31,14 @@ export default class App extends Component {
           </div>
         </nav>
         <div id="container" className="row">
-          <Map
+          <MapContainer
             center={[-3.75094, -38.576687]}
             zoom={10}
             className="map-container"
           >
             <TileLayer url="http://{s}.tile.osm.org/{z}/{x}/{y}.png" />
             <AntPath positions={this.state.path} options={this.state.options} />
-          </Map>
+          </MapContainer>
         </div>
         <div className="row" id="log-container">
           {this.state.messages.map((msg, idx) => (

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   },
   "perDependencies": {
     "leaflet": "=> 2",
-    "leaflet-ant-path": ">= 1.2.1",
+    "leaflet-ant-path": ">= 1.3.0",
     "react": ">= 16.3",
-    "react-leaflet": ">= 2"
+    "react-leaflet": ">= 3",
+    "@react-leaflet/core": ">= 3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -64,7 +65,7 @@
     "karma-jasmine": "^2.0.1",
     "karma-webpack": "^3.0.2",
     "leaflet": "^1.0.3",
-    "leaflet-ant-path": "^1.2.1",
+    "leaflet-ant-path": "^1.3.0",
     "materialize-css": "^1.0.0",
     "node-sass": "^4.11.0",
     "prettier": "1.15.3",
@@ -73,7 +74,7 @@
     "puppeteer": "^1.11.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-leaflet": "^2.0.1",
+    "react-leaflet": "^3.0.2",
     "sass-loader": "^7.1.0",
     "sinon": "^7.2.2",
     "style-loader": "^0.23.0",

--- a/src/AntPath.jsx
+++ b/src/AntPath.jsx
@@ -1,24 +1,30 @@
-import { array, object } from "prop-types";
-import { Path } from "react-leaflet";
+import { createElementHook, createPathHook, createContainerComponent } from "@react-leaflet/core"
 import { antPath } from "leaflet-ant-path";
+import PropTypes from "prop-types";
 
-export default class AntPathComponent extends Path {
-  static defaultProps = {};
+function createAntPath(props, context) {
+  const instance = antPath(props.positions, props.options)
+  return { instance, context: { ...context, overlayContainer: instance } }
+}
 
-  static propTypes = {
-    positions: array.isRequired,
-    options: object
-  };
-
-  createLeafletElement(props) {
-    const { positions, options } = props;
-    return antPath(positions, options);
+function updateAntPath(instance, props, prevProps) {
+  if (prevProps.positions !== props.positions) {
+    instance.setLatLngs(props.positions);
   }
+  instance.setStyle({ ...prevProps.options, ...props.options });
+}
 
-  updateLeafletElement(fromProps, toProps) {
-    if (toProps.positions !== fromProps.positions) {
-      this.leafletElement.setLatLngs(toProps.positions);
-    }
-    this.leafletElement.setStyle({ ...fromProps.options, ...toProps.options });
-  }
+
+const useAntPathElement = createElementHook(createAntPath, updateAntPath)
+const useAntPath = createPathHook(useAntPathElement)
+const AntPath = createContainerComponent(useAntPath)
+
+
+AntPath.propTypes = {
+  positions: PropTypes.array.isRequired,
+  options: PropTypes.object
 };
+
+AntPath.defaultProps = {};
+
+export default AntPath

--- a/src/AntPathContainer.js
+++ b/src/AntPathContainer.js
@@ -1,4 +1,3 @@
-import { withLeaflet } from "react-leaflet";
-import AntPath from "./AntPath.jsx";
+import AntPath from  "./AntPath.jsx";
 
-export default withLeaflet(AntPath);
+export default  AntPath

--- a/tests/AntPath.spec.jsx
+++ b/tests/AntPath.spec.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Map } from "react-leaflet";
+import { MapContainer } from "react-leaflet";
 import { mount } from "./enzyme";
 import { spy } from "sinon";
 import AntPath from "../src/AntPathContainer";
@@ -13,9 +13,9 @@ describe("Follow the react-leaflet component rules", () => {
 
   it("Should instantiate a ant-path when rendered inside a map", () => {
     mount(
-      <Map>
+      <MapContainer>
         <AntPath positions={[]} options={{}} />
-      </Map>
+      </MapContainer>
     );
     expect(antPathSpy.calledOnce).toBe(true);
   });
@@ -25,9 +25,9 @@ describe("Follow the react-leaflet component rules", () => {
     const options = { color: "red", pulseColor: "#FFF", delay: 100 };
 
     const wrapper = mount(
-      <Map>
+      <MapContainer>
         <AntPath positions={positions} options={options} />
-      </Map>
+      </MapContainer>
     );
     
     expect(wrapper.childAt(0).childAt(0).props()).toEqual({ positions, options });


### PR DESCRIPTION
This PR was created to solve issue #10 

I advanced `react-leaflet` to version `3.0.2` and `leaflet-ant-path` to version `1.3.0`. In 3.0.2 you no longer use `Map`, instead use `MapContainer`. I changed this in the test and in the example. Also `withLeaflet` is no longer exportet by `react-leaflet`, so i removed it. 

In `AntPath.jsx` i changed the code to use the hook-structure `react-leaflet` uses now.